### PR TITLE
New Features as requested in #7 and #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the "branch-warnings" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.0.8] - 2020-06-22
+### Changed
+- Updated readme
+### Added
+- Added support the following new extension settings "warningText" and "warningPopup" which allow users to customize the default warning messages. 
+
 ## [1.0.7] - 2020-06-02
 ### Changed
 - Updated readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 - Updated readme
 ### Added
-- Added support the following new extension settings "warningText" and "warningPopup" which allow users to customize the default warning messages. 
+- Added support the following new extension settings "warningText" and "warningPopup" which allow users to customize the default warning messages.
+- Added support for additional warnings if a remote branch exists that matches a specific regex, specified by the new "warnIfRemoteBranchExistsMatchingRegex" setting. 
 
 ## [1.0.7] - 2020-06-02
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ This extension contributes the following settings:
 
 * `branchwarnings.warningPopup`: Allows you to change the warning popup message. The default message prefix value is "WARNING: you are on the protected branch ".
 
+* `branchwarnings.warnIfRemoteBranchExistsMatchingRegex`: If set, will also provide a status warning if a branch matching the regex exists remotely. It can be used to encourage or remind users to consider if their change should go on a existing release branch, etc. If set also consider setting the "warnIfRemoteBranchExistsMatchingMsg" and "warnIfRemoteBranchExistsMatchingMsgColor" settings
+
+* `branchwarnings.warnIfRemoteBranchExistsMatchingMsg`: If "warnIfRemoteBranchExistsMatchingRegex" is set then this allows you to override the default message prefix which is "WARNING: A release branch exists ".
+
+* `branchwarnings.warnIfRemoteBranchExistsMatchingMsgColor`: If "warnIfRemoteBranchExistsMatchingRegex" is set then this allows you to override the message color which is "#ffa500". 
+
 By default, warnings will be given for branches titled "master". If you wish to warn when working on another branch such as "prerelease", add to your workspace or user settings:
 ```
 "branchwarnings.protectedBranches": [ "master", "prerelease", "releases/**" ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This extension contributes the following settings:
 
 * `branchwarnings.msgColor`: Allows you to change the color of the message on the status bar.
 
+* `branchwarnings.warningText`: Allows you to change the warning status bar message prefix. The default message prefix value is "WARNING: branch is ".
+
+* `branchwarnings.warningPopup`: Allows you to change the warning popup message. The default message prefix value is "WARNING: you are on the protected branch ".
+
 By default, warnings will be given for branches titled "master". If you wish to warn when working on another branch such as "prerelease", add to your workspace or user settings:
 ```
 "branchwarnings.protectedBranches": [ "master", "prerelease", "releases/**" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,17 @@
 {
   "name": "branch-warnings",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -75,7 +83,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -264,8 +271,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "once": {
       "version": "1.4.0",
@@ -287,6 +293,15 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
+    },
+    "simple-git": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.9.0.tgz",
+      "integrity": "sha512-rDnsMqvvk2pF7+ID8v7GtzdaXlCJfz1qFIuiQ8fcmCaqm7MITXoOx294ymSzMP0D7IC27kA5WLskkl4ZpauYNQ==",
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "debug": "^4.1.1"
+      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-warnings",
   "displayName": "Git Branch Warnings",
   "description": "Warn when you're on the wrong Git branch, like MASTER",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "publisher": "teledemic",
   "repository": {
     "type": "git",
@@ -56,6 +56,16 @@
             "type": "string",
             "default": "This branch has been marked as protected in the branch-warnings extension",
             "description": "Allows you to change the warning msg tooltip."
+          },
+          "branchwarnings.warningText": {
+            "type": "string",
+            "default": "WARNING: branch is ",
+            "description": "Allows you to change the warning status bar message."
+          },
+          "branchwarnings.warningPopup": {
+            "type": "string",
+            "default": "WARNING: you are on the protected branch ",
+            "description": "Allows you to change the warning popup message."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,21 @@
             "type": "string",
             "default": "WARNING: you are on the protected branch ",
             "description": "Allows you to change the warning popup message."
+          },
+          "branchwarnings.warnIfRemoteBranchExistsMatchingRegex": {
+            "type": "string",
+            "default": "",
+            "description": "If set, will also provide a status warning if a branch matching the regex exists remotely."
+          },
+          "branchwarnings.warnIfRemoteBranchExistsMatchingMsg": {
+            "type": "string",
+            "default": "WARNING: A release branch exists ",
+            "description": "If warnIfRemoteBranchExistsMatchingRegex is set then this allows you to override the default message."
+          },
+          "branchwarnings.warnIfRemoteBranchExistsMatchingMsgColor": {
+            "type": "string",
+            "default": "#ffa500",
+            "description": "If warnIfRemoteBranchExistsMatchingRegex is set then this allows you to override the message color."
           }
         }
       }
@@ -86,6 +101,7 @@
     "@types/mocha": "^2.2.42"
   },
   "dependencies": {
-    "glob-to-regexp": "^0.4.1"
+    "glob-to-regexp": "^0.4.1",
+    "simple-git": "^2.9.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,7 @@ function locateGitPath(startPath:string): string {
 
 function isValidGitPath(directory:string): boolean {
     const headPath = path.join(directory, GIT_IDENTIFIER);
-    let isGitRoot = fs.existsSync(headPath);
+    const isGitRoot = fs.existsSync(headPath);
     if (!isGitRoot) {
         console.log('Did not find .git folder in: ' + headPath);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ function refresh(statusLocal:vscode.StatusBarItem, statusRemote:vscode.StatusBar
 }
 
 function updateConfigs() {
-    let config = vscode.workspace.getConfiguration("branchwarnings");
+    const config = vscode.workspace.getConfiguration("branchwarnings");
 
     protectedBranches = config.get<string[]>("protectedBranches");
     suppressPopup = config.get<boolean>("suppressPopup");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,7 +141,7 @@ async function checkRemoteBranches(status: vscode.StatusBarItem) {
     // start git client using root and determine if it contains the regex
     const git2: SimpleGit = simpleGit(gitRootDir);
     try {
-        let result = await git2.listRemote(['--heads']);
+        const result = await git2.listRemote(['--heads']);
         if (result && warnIfMsg && warnIfMsg != "") {
             console.log("Raw GIT results: " + JSON.stringify(result));
             let matches = result.match(warnIfRegex);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,13 +9,12 @@ const BRANCH_PREFIX = "ref: refs/heads/";
 let protectedBranches: string[] = [];
 let suppressPopup = false;
 let lastBranch = "";
+let statusWarningText = "";
+let popupWarningText = "";
 
 export function activate(context: vscode.ExtensionContext) {
     const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 9999);
-    status.text = "WARNING";
-
     console.log("Extension branch-warnings initializing");
-
     updateConfigs(status);
 
     const gitpath = path.join(locateGitPath(vscode.workspace.rootPath), ".git");
@@ -47,6 +46,8 @@ function updateConfigs(status:vscode.StatusBarItem) {
     let config = vscode.workspace.getConfiguration("branchwarnings");
     protectedBranches = config.get<string[]>("protectedBranches");
     suppressPopup = config.get<boolean>("suppressPopup");
+    statusWarningText = config.get<string>("warningText");
+    popupWarningText = config.get<string>("warningPopup");
     status.color = config.get<string>("msgColor");
     status.tooltip = config.get<string>("msgTooltip");
 }
@@ -87,11 +88,11 @@ function updateBranch(status: vscode.StatusBarItem, path: string): void {
                     }
                 )) {
                 console.log("Branch is in protected branches [ " + protectedBranches.join(", ") + " ]");
-                status.text = "WARNING: branch is " + branch;
+                status.text = statusWarningText + branch;
                 status.show();
                 if (lastBranch != branch && !suppressPopup) {
                     console.log("Branch is a change, showing info");
-                    vscode.window.showWarningMessage("WARNING: you are on the protected branch " + branch);
+                    vscode.window.showWarningMessage(popupWarningText + branch);
                 }
             } else {
                 console.log("Branch is not in protected branches [ " + protectedBranches.join(", ") + " ]");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
     
     // Install the debugger
     const gitPath = path.join(gitRootDir, ".git");
-    let disposable = vscode.commands.registerCommand('gitbranchwarn.debug', () => {
+    const disposable = vscode.commands.registerCommand('gitbranchwarn.debug', () => {
 		// Display a message box to the user
         vscode.window.showInformationMessage('Found a .git folder at: ' + gitPath);
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -148,7 +148,7 @@ async function checkRemoteBranches(status: vscode.StatusBarItem) {
             if (matches && matches.length >= 1) {
                 console.log("Remote branch found matching the regex for a release branch [ " + warnIfRegex + " ]");
                 console.log("Found regex match: " + JSON.stringify(matches));
-                let expandedMsg = warnIfMsg + matches.join(', ');
+                const expandedMsg = warnIfMsg + matches.join(', ');
                 status.text = expandedMsg;
                 status.tooltip = expandedMsg;
                 status.color = warnIfMsgColor;


### PR DESCRIPTION
Closes #7 or at least the part we can actually do by adding new configuration settings to change the warning text prefix. 

Also closes #8 by adding support for additional warnings if a remote branch exists that matches a specific regex, specified by the new "warnIfRemoteBranchExistsMatchingRegex" setting. 